### PR TITLE
#157522894 Fix signin/signup redirection url typo

### DIFF
--- a/UI/js/app.js
+++ b/UI/js/app.js
@@ -59,14 +59,14 @@ function redirectTo(url){
 if(signinBtn){
 	signinBtn.addEventListener('click', ()=>{
 		hide(signinForm);
-		redirectTo('ui/user/dashboard.html');
+		redirectTo('UI/user/dashboard.html');
 	});
 }
 
 if(signupBtn){
 	signupBtn.addEventListener('click', ()=>{
 		hide(signinForm);
-		redirectTo('ui/user/dashboard.html');
+		redirectTo('UI/user/dashboard.html');
 	});
 }
 


### PR DESCRIPTION
# What does this PR do?
Fixes typo in signup and signin redirection url for Github Pages

# Description of Task to be completed?
URL typo breaks signin on Github Pages

# How should this be manually tested?
On Github Pages, clicking the signin and signup form button will redirect to the user dashboard

# Any background context you want to provide?
URL case matching was not an issue when working on my local machine.

# What are the relevant pivotal tracker stories?
#157522894

# Screenshots (if appropriate)
None

# Questions:
None