### PR TITLE
# 157694144 Add coveralls for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+
+after_success: 'npm run coveralls'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 [![Build Status](https://travis-ci.org/madeofhuman/Maintenance-Tracker-App.svg?branch=staging-api-v1)](https://travis-ci.org/madeofhuman/Maintenance-Tracker-App)
-[![Coverage Status](https://coveralls.io/repos/github/madeofhuman/Maintenance-Tracker-App/badge.svg?branch=master)](https://coveralls.io/github/madeofhuman/Maintenance-Tracker-App?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/madeofhuman/Maintenance-Tracker-App/badge.svg?branch=master)](https://coveralls.io/github/madeofhuman/Maintenance-Tracker-App?branch=staging-api-v1)
 
 # Maintenance-Tracker-App
 Maintenance Tracker App is an application that provides users with the ability to reach out to operations or repairs department regarding repair or maintenance requests and monitor the status of their request.


### PR DESCRIPTION
# What does this PR do?
Integrates Coveralls for test coverage reporting

# Description of Task to be completed?
Integrate test coverage reporting (eg. Coveralls) with badges in ReadMe

# How should this be manually tested?
On Github, each push to remote will trigger a TravisCI build which will run the rest coverage and provide a report

# Any background context you want to provide?
None

# What are the relevant pivotal tracker stories?
#157694144

# Screenshots (if appropriate)
None

# Questions:
None